### PR TITLE
Fix Pyside imports for new Desktop app versions

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -570,17 +570,22 @@ class CinemaEngine(Engine):
                                          "site-packages"))
 
         elif current_os == "win32":
-            desktop_path = os.environ.get("SHOTGUN_DESKTOP_INSTALL_PATH",
-                                          "C:/Program Files/Shotgun")
-            sys.path.append(os.path.join(desktop_path,
-                                         "Python", "Lib", "site-packages"))
+            desktop2_python_path = f"""{os.environ.get('SHOTGUN_DESKTOP_INSTALL_PATH', 
+                                                     'C:/Program Files/Shotgun')}/Python3/Lib/site-packages"""
+            if os.path.exists(desktop2_python_path):
+                sys.path.append(desktop2_python_path)
+
+            else:
+                desktop_python_path = f"""{os.environ.get('SHOTGUN_DESKTOP_INSTALL_PATH', 
+                                                         'C:/Program Files/Shotgun')}/Python/Lib/site-packages"""
+                if os.path.exists(desktop_python_path):
+                    sys.path.append(desktop_python_path)
 
         elif current_os == "linux2":
             desktop_path = os.environ.get("SHOTGUN_DESKTOP_INSTALL_PATH",
                                           "/opt/Shotgun/Shotgun")
             sys.path.append(os.path.join(desktop_path,
                                          "Python", "Lib", "site-packages"))
-
 
         else:
             self.logger.error("Unknown platform - cannot initialize PySide!")

--- a/engine.py
+++ b/engine.py
@@ -425,9 +425,8 @@ class CinemaEngine(Engine):
                 " changing context."
             )
 
-            # finally create the menu with the new context if needed
-            if old_context != new_context:
-                self.create_shotgun_menu()
+            # finally create the menu with the new context
+            self.create_shotgun_menu()
 
     def _run_app_instance_commands(self):
         """

--- a/engine.py
+++ b/engine.py
@@ -555,6 +555,8 @@ class CinemaEngine(Engine):
         """
         Handles the pyside init
         """
+        self.logger.info("Initializing PySide...")
+        self.logger.info(os.getenv("SHOTGUN_DESKTOP_INSTALL_PATH"))
 
         pyside_detected, pyside_version = self._detect_pyside()
         if pyside_detected:
@@ -565,7 +567,10 @@ class CinemaEngine(Engine):
         if current_os == "darwin":
             desktop_path = os.environ.get("SHOTGUN_DESKTOP_INSTALL_PATH",
                                           "/Applications/Shotgun.app")
-            sys.path.append(os.path.join(desktop_path, "Contents", "Resources",
+
+            if os.path.exists(desktop_path):
+                self.logger.info("Adding %s to sys.path", desktop_path)
+                sys.path.append(os.path.join(desktop_path, "Contents", "Resources",
                                          "Python", "lib", "python2.7",
                                          "site-packages"))
 
@@ -573,19 +578,23 @@ class CinemaEngine(Engine):
             desktop2_python_path = f"""{os.environ.get('SHOTGUN_DESKTOP_INSTALL_PATH', 
                                                      'C:/Program Files/Shotgun')}/Python3/Lib/site-packages"""
             if os.path.exists(desktop2_python_path):
+                self.logger.info("Adding %s to sys.path", desktop2_python_path)
                 sys.path.append(desktop2_python_path)
 
             else:
                 desktop_python_path = f"""{os.environ.get('SHOTGUN_DESKTOP_INSTALL_PATH', 
                                                          'C:/Program Files/Shotgun')}/Python/Lib/site-packages"""
                 if os.path.exists(desktop_python_path):
+                    self.logger.info("Adding %s to sys.path", desktop_python_path)
                     sys.path.append(desktop_python_path)
 
         elif current_os == "linux2":
             desktop_path = os.environ.get("SHOTGUN_DESKTOP_INSTALL_PATH",
                                           "/opt/Shotgun/Shotgun")
-            sys.path.append(os.path.join(desktop_path,
-                                         "Python", "Lib", "site-packages"))
+            if os.path.exists(desktop_path):
+                self.logger.info("Adding %s to sys.path", desktop_path)
+                sys.path.append(os.path.join(desktop_path,
+                                             "Python", "Lib", "site-packages"))
 
         else:
             self.logger.error("Unknown platform - cannot initialize PySide!")

--- a/engine.py
+++ b/engine.py
@@ -31,45 +31,45 @@ __contact__ = "https://www.linkedin.com/in/mykhailo-datsyk/"
 
 
 def show_error(msg):
-    print("Shotgun Error | Cinema engine | %s " % msg)
+    print("ShotGrid Error | Cinema engine | %s " % msg)
     gui.MessageDialog(
-        "Shotgun Error 'Cinema engine': \n {}".format(msg),
+        "ShotGrid Error 'Cinema engine': \n {}".format(msg),
         type=c4d.GEMB_OK
     )
 
 def show_warning(msg):
     gui.MessageDialog(
-        "Shotgun Warning 'Cinema engine': \n {}".format(msg),
+        "ShotGrid Warning 'Cinema engine': \n {}".format(msg),
         type=c4d.GEMB_OK
     )
 
 
 def show_info(msg):
     gui.MessageDialog(
-        "Shotgun Info 'Cinema engine': \n {}".format(msg),
+        "ShotGrid Info 'Cinema engine': \n {}".format(msg),
         type=c4d.GEMB_OK
     )
 
 
 def display_error(msg):
     t = time.asctime(time.localtime())
-    print("%s - Shotgun Error | Cinema engine | %s " % (t, msg))
+    print("%s - ShotGrid Error | Cinema engine | %s " % (t, msg))
 
 
 def display_warning(msg):
     t = time.asctime(time.localtime())
-    print("%s - Shotgun Warning | Cinema engine | %s " % (t, msg))
+    print("%s - ShotGrid Warning | Cinema engine | %s " % (t, msg))
 
 
 def display_info(msg):
     t = time.asctime(time.localtime())
-    print("%s - Shotgun Info | Cinema engine | %s " % (t, msg))
+    print("%s - ShotGrid Info | Cinema engine | %s " % (t, msg))
 
 
 def display_debug(msg):
     if os.environ.get("TK_DEBUG") == "1":
         t = time.asctime(time.localtime())
-        print("%s - Shotgun Debug | Cinema engine | %s " % (t, msg))
+        print("%s - ShotGrid Debug | Cinema engine | %s " % (t, msg))
 
 
 ###############################################################################
@@ -119,7 +119,7 @@ def refresh_engine(engine_name, prev_context, menu_name):
         except tank.TankError:
             (exc_type, exc_value, exc_traceback) = sys.exc_info()
             message = ""
-            message += "Shotgun Cinema Engine cannot be started:.\n"
+            message += "ShotGrid Cinema Engine cannot be started:.\n"
             message += "Please contact you technical support team for more "
             message += "information.\n\n"
             message += "Exception: %s - %s\n" % (exc_type, exc_value)
@@ -129,7 +129,7 @@ def refresh_engine(engine_name, prev_context, menu_name):
             display_error(message)
             return
 
-    # shotgun menu may have been removed, so add it back in if its not already
+    # ShotGrid menu may have been removed, so add it back in if its not already
     # there.
     current_engine.create_shotgun_menu()
 
@@ -179,7 +179,7 @@ class CinemaEngine(Engine):
     def __register_open_log_folder_command(self):
         """
         # add a 'open log folder' command to the engine's context menu
-        # note: we make an exception for the shotgun engine which is a
+        # note: we make an exception for the ShotGrid engine which is a
         # special case.
         """
         if self.name != SHOTGUN_ENGINE_NAME:
@@ -257,7 +257,7 @@ class CinemaEngine(Engine):
         Runs after the engine is set up but before any apps have been
         initialized.
         """
-        # unicode characters returned by the shotgun api need to be converted
+        # unicode characters returned by the ShotGrid api need to be converted
         # to display correctly in all of the app windows
         from tank.platform.qt import QtCore
 
@@ -283,15 +283,15 @@ class CinemaEngine(Engine):
         cinema_ver = c4d.GetC4DVersion()/1000
 
         if cinema_ver < 19:
-            msg = "Shotgun integration is not compatible with Cinema "
+            msg = "ShotGrid integration is not compatible with Cinema "
             msg += "versions older than 20.0"
             raise tank.TankError(msg)
 
         if cinema_ver > 19:
             # show a warning that this version of Cinema isn't yet fully
-            # tested with Shotgun:
+            # tested with ShotGrid:
             msg = (
-                "The Shotgun Pipeline Toolkit has not yet been fully tested "
+                "The ShotGrid Pipeline Toolkit has not yet been fully tested "
                 "with Cinema R%s.\n"
                 "You can continue to use Toolkit but you may experience bugs "
                 "or instability."
@@ -344,20 +344,20 @@ class CinemaEngine(Engine):
         # add qt paths and dlls
         self._init_pyside()
 
-        # default menu name is Shotgun but this can be overriden
+        # default menu name is ShotGrid but this can be overriden
         # in the configuration to be Sgtk in case of conflicts
-        self._menu_name = "Shotgun"
+        self._menu_name = "ShotGrid"
         if self.get_setting("use_sgtk_as_menu_name", False):
             self._menu_name = "Sgtk"
 
     def create_shotgun_menu(self):
         """
-        Creates the main shotgun menu in cinema.
+        Creates the main ShotGrid menu in cinema.
         Note that this only creates the menu, not the child actions
         :return: bool
         """
 
-        # only create the shotgun menu if not in batch mode and menu doesn't
+        # only create the ShotGrid menu if not in batch mode and menu doesn't
         # already exist
         if self.has_ui:
             # create our menu handler
@@ -471,7 +471,7 @@ class CinemaEngine(Engine):
                     # Run all commands of the given app instance.
                     # Run these commands once Cinema will have completed its
                     # UI update and be idle in order to run them after the ones
-                    # that restore the persisted Shotgun app panels.
+                    # that restore the persisted ShotGrid app panels.
                     for (
                         command_name,
                         command_function,
@@ -488,7 +488,7 @@ class CinemaEngine(Engine):
                     # 'run_at_startup' setting.
                     # Run this command once Cinema will have completed its
                     # UI update and be idle in order to run it after the ones
-                    # that restore the persisted Shotgun app panels.
+                    # that restore the persisted ShotGrid app panels.
                     command_function = command_dict.get(setting_command_name)
                     if command_function:
                         self.logger.debug(
@@ -555,8 +555,8 @@ class CinemaEngine(Engine):
         """
         Handles the pyside init
         """
-        self.logger.info("Initializing PySide...")
-        self.logger.info(os.getenv("SHOTGUN_DESKTOP_INSTALL_PATH"))
+        self.logger.debug("Initializing PySide...")
+        self.logger.debug(os.getenv("SHOTGUN_DESKTOP_INSTALL_PATH"))
 
         pyside_detected, pyside_version = self._detect_pyside()
         if pyside_detected:
@@ -569,7 +569,7 @@ class CinemaEngine(Engine):
                                           "/Applications/Shotgun.app")
 
             if os.path.exists(desktop_path):
-                self.logger.info("Adding %s to sys.path", desktop_path)
+                self.logger.debug("Adding %s to sys.path", desktop_path)
                 sys.path.append(os.path.join(desktop_path, "Contents", "Resources",
                                          "Python", "lib", "python2.7",
                                          "site-packages"))
@@ -578,21 +578,21 @@ class CinemaEngine(Engine):
             desktop2_python_path = f"""{os.environ.get('SHOTGUN_DESKTOP_INSTALL_PATH', 
                                                      'C:/Program Files/Shotgun')}/Python3/Lib/site-packages"""
             if os.path.exists(desktop2_python_path):
-                self.logger.info("Adding %s to sys.path", desktop2_python_path)
+                self.logger.debug("Adding %s to sys.path", desktop2_python_path)
                 sys.path.append(desktop2_python_path)
 
             else:
                 desktop_python_path = f"""{os.environ.get('SHOTGUN_DESKTOP_INSTALL_PATH', 
                                                          'C:/Program Files/Shotgun')}/Python/Lib/site-packages"""
                 if os.path.exists(desktop_python_path):
-                    self.logger.info("Adding %s to sys.path", desktop_python_path)
+                    self.logger.debug("Adding %s to sys.path", desktop_python_path)
                     sys.path.append(desktop_python_path)
 
         elif current_os == "linux2":
             desktop_path = os.environ.get("SHOTGUN_DESKTOP_INSTALL_PATH",
                                           "/opt/Shotgun/Shotgun")
             if os.path.exists(desktop_path):
-                self.logger.info("Adding %s to sys.path", desktop_path)
+                self.logger.debug("Adding %s to sys.path", desktop_path)
                 sys.path.append(os.path.join(desktop_path,
                                              "Python", "Lib", "site-packages"))
 
@@ -639,15 +639,15 @@ class CinemaEngine(Engine):
         :type record: :class:`~python.logging.LogRecord`
         """
         # Give a standard format to the message:
-        #     Shotgun <basename>: <message>
+        #     ShotGrid <basename>: <message>
         # where "basename" is the leaf part of the logging record name,
         # for example "tk-multi-shotgunpanel" or "qt_importer".
         if record.levelno < logging.INFO:
             formatter = logging.Formatter(
-                "Debug: Shotgun %(basename)s: %(message)s"
+                "Debug: ShotGrid %(basename)s: %(message)s"
             )
         else:
-            formatter = logging.Formatter("Shotgun %(basename)s: %(message)s")
+            formatter = logging.Formatter("ShotGrid %(basename)s: %(message)s")
 
         msg = formatter.format(record)
 
@@ -699,7 +699,7 @@ class CinemaEngine(Engine):
             c4d._shotgun_cache = {'DOCUMENT_CONTEXT_MAP': {}}
 
     def get_document_context(self, doc_path):
-        '''Retrieve a shotgun context using a document's file path.
+        '''Retrieve a ShotGrid context using a document's file path.
 
         Falls back to tk.context_from_path.
         '''

--- a/info.yml
+++ b/info.yml
@@ -58,7 +58,7 @@ configuration:
 
     use_sgtk_as_menu_name:
         type: bool
-        description: Optionally choose to use 'Sgtk' as the primary menu name instead of 'Shotgun'
+        description: Optionally choose to use 'Sgtk' as the primary menu name instead of 'ShotGrid'
         default_value: false
 
     launch_builtin_plugins:
@@ -75,8 +75,8 @@ configuration:
 requires_shotgun_fields:
         
 # More verbose description of this item 
-display_name: "Shotgun Engine for Cinema"
-description: "Shotgun Integration in Cinema"
+display_name: "ShotGrid Engine for Cinema"
+description: "ShotGrid Integration in Cinema"
 
 # Required minimum versions for this item to run
 requires_shotgun_version:

--- a/python/tk_cinema/constant_apps.py
+++ b/python/tk_cinema/constant_apps.py
@@ -22,7 +22,7 @@
 
 menu_prebuild = [
      ["Separator", "0", "separator"],
-     ["Jump to Shotgun", "2701393", "submenu"],
+     ["Jump to ShotGrid", "2701393", "submenu"],
      ["Jump to File System", "2158662", "submenu"],
      ["Jump to Screening Room in RV", "2188709", "submenu"],
      ["Jump to Screening Room Web Player", "2419038", "submenu"],
@@ -38,6 +38,6 @@ menu_prebuild = [
      ["Scene Breakdown...", "1506973", "main"],
      ["ShotGrid Panel...", "2399777", "main"],
      ["Snapshot History...", "3313077", "main"],
-     ["Sync Frame Range with Shotgun", "3366874", "main"],
+     ["Sync Frame Range with ShotGrid", "3366874", "main"],
      ["Separator", "0", "separator"],
 ]

--- a/python/tk_cinema/constant_apps.py
+++ b/python/tk_cinema/constant_apps.py
@@ -36,7 +36,7 @@ menu_prebuild = [
      ["Load...", "3279052", "main"],
      ["Separator", "0", "separator"],
      ["Scene Breakdown...", "1506973", "main"],
-     ["Shotgun Panel...", "2399777", "main"],
+     ["ShotGrid Panel...", "2399777", "main"],
      ["Snapshot History...", "3313077", "main"],
      ["Sync Frame Range with Shotgun", "3366874", "main"],
      ["Separator", "0", "separator"],

--- a/python/tk_cinema/constant_apps.py
+++ b/python/tk_cinema/constant_apps.py
@@ -32,7 +32,7 @@ menu_prebuild = [
      ["File Open...", "1760964", "main"],
      ["Snapshot...", "2436236", "main"],
      ["File Save...", "1825592", "main"],
-     ["Publish...", "3378887", "main"],
+     # ["Cinema Publish...", "3126622", "main"],
      ["Load...", "3279052", "main"],
      ["Separator", "0", "separator"],
      ["Scene Breakdown...", "1506973", "main"],

--- a/python/tk_cinema/menu_generation.py
+++ b/python/tk_cinema/menu_generation.py
@@ -57,7 +57,8 @@ class MenuGenerator(object):
             elif "main" in place:
                 menu.InsData(c4d.MENURESOURCE_COMMAND, "PLUGIN_CMD_{}".format(app_id))
             else:
-                menu.InsData(c4d.MENURESOURCE_SEPERATOR, True)
+                # c4d.MENURESOURCE_SEPERATOR renamed in 2024 use int value instead
+                menu.InsData(2, True)
 
         menu.InsData(c4d.MENURESOURCE_SUBMENU, submenu)
         mainMenu.InsData(c4d.MENURESOURCE_STRING, menu)

--- a/startup.py
+++ b/startup.py
@@ -20,18 +20,18 @@ class CinemaLauncher(SoftwareLauncher):
     # matching against supplied versions and products. Similar to the glob
     # strings, these allow us to alter the regex matching for any of the
     # variable components of the path in one place
-    COMPONENT_REGEX_LOOKUP = {"version": r"R\d\d"}
+    COMPONENT_REGEX_LOOKUP = {"version": r"R\d\d|\d\d\d\d|\d\d\d\d\.\d"}
 
     EXECUTABLE_TEMPLATES = {
         "darwin": [
             "/Applications/MAXON/Cinema 4D {version}/CINEMA 4D.app",
-            "$CINEMA_BIN_DIR/CINEMA 4D.app"
+            "$CINEMA_BIN_DIR/CINEMA 4D.app",
         ],
         "win32": [
             "C:/Program Files/MAXON/Cinema 4D {version}/CINEMA 4D.exe",
             "C:/Program Files/MAXON Cinema 4D {version}/CINEMA 4D.exe",
-            "$CINEMA_BIN_DIR/CINEMA 4D.exe"
-        ]
+            "$CINEMA_BIN_DIR/CINEMA 4D.exe",
+        ],
     }
 
     @property
@@ -59,35 +59,32 @@ class CinemaLauncher(SoftwareLauncher):
         # by appending it to the env PYTHONPATH.
         startup_path = os.path.join(self.disk_location, "startup")
 
-        sgtk.util.append_path_to_env_var(
-            "g_additionalModulePath", startup_path
-        )
-        required_env["g_additionalModulePath"] = os.environ[
-            "g_additionalModulePath"
-        ]
+        sgtk.util.append_path_to_env_var("g_additionalModulePath", startup_path)
+        required_env["g_additionalModulePath"] = os.environ["g_additionalModulePath"]
 
-        if 'R23' in exec_path:
+        if "R23" in exec_path:
             # Get Qt Site - when launching from Shotgun Desktop this should
             # point to the installs lib/site-packages directory.
             try:
                 from sgtk.platform.qt import QtCore
+
                 qt_site = os.path.dirname(os.path.dirname(QtCore.__file__))
                 sgtk.util.append_path_to_env_var("PYTHONPATH", qt_site)
             except ImportError:
                 pass
 
         sgtk.util.append_path_to_env_var(
-            "PYTHONPATH", os.path.join(startup_path, 'libs')
+            "PYTHONPATH", os.path.join(startup_path, "libs")
         )
         required_env["PYTHONPATH"] = os.environ["PYTHONPATH"]
         required_env["C4DPYTHONPATH37"] = os.environ["PYTHONPATH"]  # R23
-        required_env["C4DPYTHONPATH39"] = os.environ["PYTHONPATH"]  # R24
+        required_env["C4DPYTHONPATH39"] = os.environ["PYTHONPATH"]  # R24-2023.1
+        required_env["C4DPYTHONPATH310"] = os.environ["PYTHONPATH"]  # 2023.2
+        required_env["C4DPYTHONPATH311"] = os.environ["PYTHONPATH"]  # 2024
 
         # Prepare the launch environment with variables required by the
         # classic bootstrap approach.
-        self.logger.debug(
-            "Preparing Cinema Launch via Toolkit Classic methodology ..."
-        )
+        self.logger.debug("Preparing Cinema Launch via Toolkit Classic methodology ...")
         required_env["SGTK_ENGINE"] = self.engine_name
         required_env["SGTK_CONTEXT"] = sgtk.context.serialize(self.context)
 
@@ -127,8 +124,7 @@ class CinemaLauncher(SoftwareLauncher):
                 supported_sw_versions.append(sw_version)
             else:
                 self.logger.debug(
-                    "SoftwareVersion %s is not supported: %s"
-                    % (sw_version, reason)
+                    "SoftwareVersion %s is not supported: %s" % (sw_version, reason)
                 )
 
         return supported_sw_versions
@@ -155,13 +151,12 @@ class CinemaLauncher(SoftwareLauncher):
             )
 
             # Extract all products from that executable.
-            for (executable_path, key_dict) in executable_matches:
-
+            for executable_path, key_dict in executable_matches:
                 # extract the matched keys form the key_dict.
                 # in the case of version we return something different than
                 # an empty string because there are cases were the installation
                 # directories do not include version number information.
-                executable_version = key_dict.get("version", " ").lstrip('R')
+                executable_version = key_dict.get("version", " ").lstrip("R")
 
                 sw_versions.append(
                     SoftwareVersion(

--- a/startup/shotgun.pyp
+++ b/startup/shotgun.pyp
@@ -34,7 +34,7 @@ menu_prebuild = [
     ['Load...', '3279052'],
     ['Reload and Restart', '5919542'],
     ['Work Area Info...', '2574358'],
-    ['Shotgun Panel...', '2399777'],
+    ['ShotGrid Panel...', '2399777'],
     ['Publish...', '3378887'],
     ['Sync Frame Range with Shotgun', '3366874'],
     ['Snapshot History...', '3313077'],

--- a/startup/shotgun.pyp
+++ b/startup/shotgun.pyp
@@ -159,7 +159,7 @@ class SceneChangeEvent(c4d.plugins.MessageData):
 def EnhanceMainMenu():
     mainMenu = c4d.gui.GetMenuResource("M_EDITOR")
     menu = c4d.BaseContainer()
-    menu.InsData(c4d.MENURESOURCE_SUBTITLE, "Shotgun")
+    menu.InsData(c4d.MENURESOURCE_SUBTITLE, "ShotGrid")
 
     submenu = c4d.BaseContainer()
     submenu.InsData(c4d.MENURESOURCE_SUBTITLE, "{}".format(engine.context))


### PR DESCRIPTION
New Desktop Apps have an altered folder stucture with renamed folders for the shipped python install.
This pull request fixed the engine so it will look at the Pyside6 install shipped with Sg Desktop which is compatible with Cinema4D 2024.2+.